### PR TITLE
Add Utilia Solana Preflight MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A curated list of awesome Solana Model Context Protocol (MCP) servers and relate
 - [Memecoin Observatory MCP](https://github.com/tony-42069/solana-mcp.git) - A comprehensive Solana MCP server for analyzing memecoins, tracking trends, and providing AI-powered insights using cultural analysis and on-chain data. Features real-time memecoin radar, social signal analysis, whale wallet tracking, and rugpull protection.
 - [Solana Wallet Security Scanner](https://github.com/mohitparmar1/Solana-Wallet-Security-Scanner) - A MCP server that implements a Solana security analysis system. It allows users to scan wallets for threats, detect suspicious programs, and provides tools for monitoring blockchain activity via @solana/web3.js.
 - [MCP Meme Deployer](https://github.com/kirabuilds/mcp-meme-deployer) - A Model Context Protocol (MCP) server that allows Claude Desktop to deploy instantly tradable tokens on Solana at zero cost with just a simple conversation.
-- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-x402) - A remote MCP server for live Solana priority-fee estimates, unsigned transaction simulation, confirmed-transaction diagnosis, and SPL token-risk inspection. Tools are available without API keys and use pay-per-call x402 USDC micropayments on Solana or Base.
+- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-solana-agent) - A remote MCP server for live Solana priority-fee estimates, unsigned transaction simulation, confirmed-transaction diagnosis, SPL token-risk inspection, PDF conversion, and audio normalization. No API key is required; MCP tool calls use pay-per-call x402 USDC payments on Solana.
 
 
 ## Tools and Libraries

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A curated list of awesome Solana Model Context Protocol (MCP) servers and relate
 - [Memecoin Observatory MCP](https://github.com/tony-42069/solana-mcp.git) - A comprehensive Solana MCP server for analyzing memecoins, tracking trends, and providing AI-powered insights using cultural analysis and on-chain data. Features real-time memecoin radar, social signal analysis, whale wallet tracking, and rugpull protection.
 - [Solana Wallet Security Scanner](https://github.com/mohitparmar1/Solana-Wallet-Security-Scanner) - A MCP server that implements a Solana security analysis system. It allows users to scan wallets for threats, detect suspicious programs, and provides tools for monitoring blockchain activity via @solana/web3.js.
 - [MCP Meme Deployer](https://github.com/kirabuilds/mcp-meme-deployer) - A Model Context Protocol (MCP) server that allows Claude Desktop to deploy instantly tradable tokens on Solana at zero cost with just a simple conversation.
+- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-x402) - A remote MCP server for live Solana priority-fee estimates, unsigned transaction simulation, confirmed-transaction diagnosis, and SPL token-risk inspection. Tools are available without API keys and use pay-per-call x402 USDC micropayments on Solana or Base.
 
 
 ## Tools and Libraries

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,7 @@
 - [Memecoin Observatory MCP](https://github.com/tony-42069/solana-mcp.git) - 一个全面的 Solana MCP 服务器，用于分析迷因币、跟踪趋势，并通过文化分析和链上数据提供 AI 驱动的见解。具有实时迷因币雷达、社交信号分析、鲸鱼钱包跟踪和跑路保护功能。
 - [Solana Wallet Security Scanner](https://github.com/mohitparmar1/Solana-Wallet-Security-Scanner) - 一个实现 Solana 安全分析系统的 MCP 服务器。它允许用户扫描钱包威胁，检测可疑程序，并提供通过 @solana/web3.js 监控区块链活动的工具。
 - [MCP Meme Deployer](https://github.com/kirabuilds/mcp-meme-deployer) - 一个模型上下文协议（MCP）服务器，允许 Claude Desktop 通过简单的对话在 Solana 上以零成本部署即时可交易的代币。
+- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-x402) - 一个远程 MCP 服务器，提供实时 Solana 优先费估算、未签名交易模拟、已确认交易诊断和 SPL 代币风险检查。无需 API 密钥，并支持通过 Solana 或 Base 上的 x402 USDC 微支付按次付费。
 
 ## 工具和库
 - [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit) - 用于将 AI 代理连接到 Solana 协议的工具包。具有跨链操作、代币管理、Voltr 金库交互和基于 LangGraph 的多代理系统支持。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,7 +26,7 @@
 - [Memecoin Observatory MCP](https://github.com/tony-42069/solana-mcp.git) - 一个全面的 Solana MCP 服务器，用于分析迷因币、跟踪趋势，并通过文化分析和链上数据提供 AI 驱动的见解。具有实时迷因币雷达、社交信号分析、鲸鱼钱包跟踪和跑路保护功能。
 - [Solana Wallet Security Scanner](https://github.com/mohitparmar1/Solana-Wallet-Security-Scanner) - 一个实现 Solana 安全分析系统的 MCP 服务器。它允许用户扫描钱包威胁，检测可疑程序，并提供通过 @solana/web3.js 监控区块链活动的工具。
 - [MCP Meme Deployer](https://github.com/kirabuilds/mcp-meme-deployer) - 一个模型上下文协议（MCP）服务器，允许 Claude Desktop 通过简单的对话在 Solana 上以零成本部署即时可交易的代币。
-- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-x402) - 一个远程 MCP 服务器，提供实时 Solana 优先费估算、未签名交易模拟、已确认交易诊断和 SPL 代币风险检查。无需 API 密钥，并支持通过 Solana 或 Base 上的 x402 USDC 微支付按次付费。
+- [Utilia Solana Preflight](https://github.com/mohamedkuch/utilia-solana-agent) - 一个远程 MCP 服务器，提供实时 Solana 优先费估算、未签名交易模拟、已确认交易诊断、SPL 代币风险检查、PDF 转换和音频标准化。无需 API 密钥；MCP 工具调用通过 Solana 上的 x402 USDC 按次付费。
 
 ## 工具和库
 - [Solana Agent Kit](https://github.com/sendaifun/solana-agent-kit) - 用于将 AI 代理连接到 Solana 协议的工具包。具有跨链操作、代币管理、Voltr 金库交互和基于 LangGraph 的多代理系统支持。


### PR DESCRIPTION
Adds Utilia Solana Preflight to both the English and Simplified Chinese server lists.

Utilia exposes six read-only MCP tools for:
- Solana priority-fee estimates
- unsigned transaction simulation
- confirmed-transaction diagnosis
- SPL token-risk inspection
- PDF-to-Markdown conversion
- audio normalization

No API key is required. Hosted MCP tool payments settle in USDC on Solana mainnet. Separate HTTP aliases expose the same capabilities with x402 USDC settlement on Base; those aliases are not evidence of an independent Base customer payment. The public buyer client, remote endpoint, and documentation are linked from the submitted entry.